### PR TITLE
chore(backend): enable stable dockerized api startup with compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+bin/
+obj/
+.git/
+.gitignore
+.vs/
+node_modules/
+Dockerfile*
+docker-compose*
+*.user
+*.suo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY ["RoomBooking.Api.csproj", "./"]
+RUN dotnet restore "RoomBooking.Api.csproj"
+
+COPY . .
+RUN dotnet publish "RoomBooking.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+
+COPY --from=build /app/publish .
+
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "RoomBooking.Api.dll"]


### PR DESCRIPTION
Closes #9 

## Summary
Menstabilkan proses startup backend dalam environment Docker Compose bersama SQL Server.

## Changes
- Gunakan konfigurasi Docker Compose yang menjalankan API backend dan SQL Server secara terintegrasi.
- Validasi build image backend dan startup sequence saat database healthy.
- Verifikasi konektivitas service backend via port expose compose.

## Why
Diperlukan runtime backend yang konsisten di local environment agar frontend-backend-db bisa dijalankan end-to-end tanpa setup manual terpisah.

## Validation
- `docker compose up --build -d` berhasil.
- Container backend status `Up`.
- Container db status `Up (healthy)`.
- API backend dapat diakses di `http://localhost:5271`.

## Type
- [x] Chore (infra/docker)